### PR TITLE
Created .gitignore file to prevent botConfig files from being committed to the repo again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 # Prevent all botConfig.json files from being committed to the repo to protect bot token
-# *botConfig.json
+*botConfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 # Prevent all botConfig.json files from being committed to the repo to protect bot token
-*botConfig.json
+# *botConfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Prevent all botConfig.json files from being committed to the repo to protect bot token
+*botConfig.json

--- a/config/botConfig.json
+++ b/config/botConfig.json
@@ -1,4 +1,0 @@
-{
-	"prefix": "Change this to the prefered prefix",
-	"token": "Change this to your application's token"
-}

--- a/config/botConfig.json
+++ b/config/botConfig.json
@@ -1,0 +1,4 @@
+{
+  "prefix": "Change this to the prefered prefix",
+  "token": "Change this to your application's token"
+}


### PR DESCRIPTION
With the new .gitignore file, this will let you keep the `botConfig.json` file in your local repo folder on your computer so you can run the bot, but every time you commit to the repository it will exclude the `botConfig.json` file from being uploaded.

If the key is uploaded to GitHub, everybody would be able to see it and make SamanthaBot run any code - potentially malicious. If this did accidentally happen though, you can make a new key through the Discord bot portal.